### PR TITLE
minor correctino 7chars to 9chars because word had 9 chars

### DIFF
--- a/lib/io/pwm.cpp
+++ b/lib/io/pwm.cpp
@@ -152,7 +152,7 @@ core::Result Pwm::setPeriod(const std::uint32_t period, const int period_file)
 core::Result Pwm::setPolarity(const Polarity polarity, const int polarity_file)
 {
   const std::uint8_t polarity_value = static_cast<std::uint8_t>(polarity);
-  char write_buffer[7];
+  char write_buffer[9];
   if (polarity_value == 0) {
     snprintf(write_buffer, sizeof(write_buffer), "normal");
   } else {


### PR DESCRIPTION
Minor bug where the max length of a string was 7chars, but one of the possible strings was 9chars. So I put the size up to 9.