### PR TITLE
MGT - Fix github CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Test
         run: ctest
         working-directory: build
-
+  # TODOLater this can be merged with the above once the issue is resolved
   mac-build:
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           chmod +x ./llvm.sh
           sudo ./llvm.sh 17
+        if: runner.os == 'Linux'
       - name: CMake
         run: cmake -S . -B build -DCMAKE_CXX_COMPILER=$(clang++-17)
       - name: Build hyped

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
           sudo ./llvm.sh 17
         if: runner.os == 'Linux'
       - name: CMake
-        run: cmake -S . -B build -DCMAKE_CXX_COMPILER=$(clang++-17)
+        run: cmake -S . -B build -DCMAKE_CXX_COMPILER=clang++-17
       - name: Build hyped
         run: make -j
         working-directory: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,14 @@ jobs:
             apt: libeigen3-dev libboost-all-dev
           macos: |
             brew: eigen boost
+      # TODOLater this is a workaround due to https://github.com/actions/runner-images/issues/8659, remove once fixed
+      - name: Install newer Clang
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x ./llvm.sh
+          sudo ./llvm.sh 17
       - name: CMake
-        run: cmake -S . -B build -DCMAKE_CXX_COMPILER=$(which clang++)
+        run: cmake -S . -B build -DCMAKE_CXX_COMPILER=$(clang++-17)
       - name: Build hyped
         run: make -j
         working-directory: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,10 @@ on:
       - "telemetry/**"
 
 jobs:
-  build:
+  linux-build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -28,9 +28,33 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           chmod +x ./llvm.sh
           sudo ./llvm.sh 17
-        if: runner.os == 'Linux'
       - name: CMake
         run: cmake -S . -B build -DCMAKE_CXX_COMPILER=clang++-17
+      - name: Build hyped
+        run: make -j
+        working-directory: build
+      - name: Test
+        run: ctest
+        working-directory: build
+
+  mac-build:
+    strategy:
+      matrix:
+        os: [macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        uses: jrl-umi3218/github-actions/install-dependencies@master
+        with:
+          compiler: clang
+          ubuntu: |
+            apt: libeigen3-dev libboost-all-dev
+          macos: |
+            brew: eigen boost
+      - name: CMake
+        run: cmake -S . -B build -DCMAKE_CXX_COMPILER=$(which clang++)
       - name: Build hyped
         run: make -j
         working-directory: build


### PR DESCRIPTION
Due to https://github.com/actions/runner-images/issues/8659, we have to manually install and use clang-17 or every `#include <chrono>` breaks. This will be removed once either the issue is fixed or I set up the docker build image.

It also adds ~30s to the linux build, sorry about that