### PR TITLE
TEL - Docker!

### DIFF
--- a/telemetry/.dockerignore
+++ b/telemetry/.dockerignore
@@ -2,6 +2,11 @@
 dist
 node_modules
 
+# docker config
+Dockerfile
+docker-compose.yml
+.dockerignore
+
 # Logs
 logs
 *.log
@@ -27,14 +32,3 @@ lerna-debug.log*
 .settings/
 *.sublime-workspace
 .turbo
-
-# .env files
-.env
-.env.docker
-
-# influx data
-influxdb/data
-
-# mosquitto persistence & logs
-mosquitto/data
-mosquitto/log

--- a/telemetry/Dockerfile
+++ b/telemetry/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:18.17.0
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install dependencies
+COPY package.json ./
+COPY packages/constants/package.json ./packages/constants/
+COPY packages/server/package.json ./packages/server/
+COPY packages/types/package.json ./packages/types/
+COPY packages/ui/package.json ./packages/ui/
+COPY yarn.lock ./
+COPY patches ./patches
+RUN yarn install
+
+# Copy all source files
+COPY . .
+
+# Replace server/ui .env with .env.docker
+RUN cp packages/server/.env.docker packages/server/.env
+RUN cp packages/ui/.env.docker packages/ui/.env
+
+# Build app
+RUN yarn build
+
+# Expose ports
+EXPOSE 5173
+EXPOSE 3000
+
+# Start app
+CMD [ "yarn", "dev" ]

--- a/telemetry/docker-compose.yml
+++ b/telemetry/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '3'
+
+services:
+  telemetry:
+    container_name: telemetry
+    build: .
+    ports:
+      - 5173:5173
+      - 3000:3000
+  influxdb:
+    container_name: influxdb
+    image: influxdb:2.7
+    ports:
+      - 8086:8086
+    volumes:
+      - ./influxdb/data:/var/lib/influxdb2
+      - ./influxdb/config:/etc/influxdb2
+      - ./influxdb/scripts:/docker-entrypoint-initdb.d
+    environment:
+      - DOCKER_INFLUXDB_INIT_MODE=setup
+      - DOCKER_INFLUXDB_INIT_USERNAME=hyped
+      - DOCKER_INFLUXDB_INIT_PASSWORD=edinburgh
+      - DOCKER_INFLUXDB_INIT_ORG=hyped
+      - DOCKER_INFLUXDB_INIT_BUCKET=telemetry
+      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=edinburgh
+  mosquitto:
+    container_name: mosquitto
+    image: eclipse-mosquitto:2.0.18
+    ports:
+      - 1883:1883
+      - 8080:8080
+    volumes:
+      - ./mosquitto/config:/mosquitto/config
+      - ./mosquitto/data:/mosquitto/data
+      - ./mosquitto/log:/mosquitto/log
+
+volumes:
+  influxdb:
+  mosquitto:

--- a/telemetry/influxdb/config/influx-configs
+++ b/telemetry/influxdb/config/influx-configs
@@ -1,0 +1,20 @@
+[default]
+  url = "http://localhost:8086"
+  token = "edinburgh"
+  org = "hyped"
+  active = true
+# 
+# [eu-central]
+#   url = "https://eu-central-1-1.aws.cloud2.influxdata.com"
+#   token = "XXX"
+#   org = ""
+# 
+# [us-central]
+#   url = "https://us-central1-1.gcp.cloud2.influxdata.com"
+#   token = "XXX"
+#   org = ""
+# 
+# [us-west]
+#   url = "https://us-west-2-1.aws.cloud2.influxdata.com"
+#   token = "XXX"
+#   org = ""

--- a/telemetry/influxdb/scripts/setup.sh
+++ b/telemetry/influxdb/scripts/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+set -e
+influx bucket create -n faults

--- a/telemetry/mosquitto/config/mosquitto.conf
+++ b/telemetry/mosquitto/config/mosquitto.conf
@@ -1,0 +1,14 @@
+# mqtt protocol
+listener 1883
+protocol mqtt
+
+# websockets protocol (for GUI)
+listener 8080
+protocol websockets
+
+allow_anonymous true
+
+# persistence & logs
+persistence true
+persistence_location /mosquitto/data/
+log_dest file /mosquitto/log/mosquitto.log

--- a/telemetry/packages/server/.env.example
+++ b/telemetry/packages/server/.env.example
@@ -1,0 +1,10 @@
+# Example of .env file
+# .env file is used to set environment variables for local development
+# .env.docker file is used to set environment variables for docker container
+
+INFLUX_URL=
+INFLUX_TOKEN=
+INFLUX_ORG=
+INFLUX_TELEMETRY_BUCKET=
+INFLUX_FAULTS_BUCKET=
+MQTT_BROKER_HOST=

--- a/telemetry/packages/ui/.env.example
+++ b/telemetry/packages/ui/.env.example
@@ -1,0 +1,6 @@
+# Example of .env file
+# .env file is used to set environment variables for local development
+# .env.docker file is used to set environment variables for docker container
+
+SERVER_URL=
+HOST=

--- a/telemetry/packages/ui/vite.config.ts
+++ b/telemetry/packages/ui/vite.config.ts
@@ -1,11 +1,15 @@
 import { resolve } from 'path';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command, mode }) => {
+  process.env = { ...process.env, ...loadEnv(mode, process.cwd(), '') };
   return {
+    server: {
+      host: process.env.HOST || 'localhost',
+    },
     build: {
       rollupOptions: {
         input: {

--- a/telemetry/yarn.lock
+++ b/telemetry/yarn.lock
@@ -1517,11 +1517,6 @@
   resolved "https://registry.yarnpkg.com/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
 
-"@influxdata/influxdb-client-apis@^1.33.2":
-  version "1.33.2"
-  resolved "https://registry.yarnpkg.com/@influxdata/influxdb-client-apis/-/influxdb-client-apis-1.33.2.tgz#792f4ae3930588cee6ac20c1192bf8c38dbd0765"
-  integrity sha512-W6x9TOAQ3AUx0RBCrCibDhSvMqN50lxJmElc3rHn7+R/9Zi35oczu8r9YMkyNlzWnksu+dcyKr8/xLv28Ot4hw==
-
 "@influxdata/influxdb-client@^1.33.1":
   version "1.33.2"
   resolved "https://registry.yarnpkg.com/@influxdata/influxdb-client/-/influxdb-client-1.33.2.tgz#c68cfcf592e4e042361003143fbab99461410172"


### PR DESCRIPTION
In a staggering feat of procrastination, I have finally dockerized telemetry 🥳 (I think)

Just run `docker-compose up --build` in `/telemetry` and it'll spin up all of the telemetry services, mosquitto (MQTT broker) and InfluxDB (the time-series database we use for saving historical readings) all fully configured. The GUI should then be available at `localhost:5173`, MQTT broker on `localhost:1883` and the InfluxDB management dashboard at `localhost:8086`.