### PR TITLE
SNS - 16-Bit I2C

### DIFF
--- a/lib/debug/commands/i2c_commands.cpp
+++ b/lib/debug/commands/i2c_commands.cpp
@@ -47,7 +47,8 @@ core::Result I2cCommands::addCommands(core::ILogger &logger,
     const auto write_command_name        = std::to_string(bus) + " write";
     const auto write_command_description = "Write to I2C bus " + std::to_string(bus);
     const auto write_command_handler     = [&logger, i2c, bus]() {
-      std::uint32_t device_address, register_address, data;
+      std::uint32_t device_address, data;
+      std::uint16_t register_address;
       std::cout << "Device address: ";
       std::cin >> std::hex >> device_address;
       std::cout << "Register address: ";

--- a/lib/io/hardware_i2c.cpp
+++ b/lib/io/hardware_i2c.cpp
@@ -70,34 +70,33 @@ core::Result HardwareI2c::writeByteToRegister(const std::uint8_t device_address,
                                               const std::uint8_t register_address,
                                               const std::uint8_t data)
 {
-  const std::uint8_t register_address_array[2] = {0x00, register_address};
-  return writeByteToDevice(device_address, register_address_array, data);
+  const std::vector<std::uint8_t> bytes = {register_address, data};
+  return writeBytesToDevice(device_address, bytes);
 }
 
 core::Result HardwareI2c::writeByteToRegister(const std::uint8_t device_address,
                                               const std::uint16_t register_address,
                                               const std::uint8_t data)
 {
-  // TODOLater - Is this the best way to do this?
-  const std::uint8_t register_address_hi       = register_address >> 8;
-  const std::uint8_t register_address_lo       = static_cast<std::uint8_t>(register_address);
-  const std::uint8_t register_address_array[2] = {register_address_hi, register_address_lo};
-  return writeByteToDevice(device_address, register_address_array, data);
+  const std::uint8_t register_address_hi = register_address >> 8;
+  const std::uint8_t register_address_lo = static_cast<std::uint8_t>(register_address);
+  const std::vector<std::uint8_t> bytes  = {register_address_hi, register_address_lo, data};
+  return writeBytesToDevice(device_address, bytes);
 }
 
 // TODOLater - Test code
-core::Result HardwareI2c::writeByteToDevice(const std::uint8_t device_address,
-                                            const std::uint8_t register_address_array[2],
-                                            const std::uint8_t data)
+core::Result HardwareI2c::writeBytesToDevice(const std::uint8_t device_address,
+                                             const std::vector<std::uint8_t> bytes)
 {
   if (sensor_address_ != device_address) { setSensorAddress(device_address); }
-  const std::uint8_t write_buffer[3] = {register_address_array[1], register_address_array[0], data};
-  const ssize_t num_bytes_written    = write(file_descriptor_, write_buffer, 3);
-  if (num_bytes_written != 3) {
+  const std::size_t number_of_bytes = bytes.size();
+  const std::uint8_t *write_buffer  = bytes.data();
+  const ssize_t num_bytes_written   = write(file_descriptor_, write_buffer, number_of_bytes);
+  if (num_bytes_written != number_of_bytes) {
     logger_.log(core::LogLevel::kFatal, "Failed to write to i2c device");
     return core::Result::kFailure;
   }
-  logger_.log(core::LogLevel::kDebug, "Successfully wrote byte to i2c device register");
+  logger_.log(core::LogLevel::kDebug, "Successfully wrote bytes to i2c device register");
   return core::Result::kSuccess;
 }
 

--- a/lib/io/hardware_i2c.cpp
+++ b/lib/io/hardware_i2c.cpp
@@ -86,7 +86,7 @@ core::Result HardwareI2c::writeByteToRegister(const std::uint8_t device_address,
 
 // TODOLater - Test code
 core::Result HardwareI2c::writeBytesToDevice(const std::uint8_t device_address,
-                                             const std::vector<std::uint8_t> bytes)
+                                             const std::vector<std::uint8_t> &bytes)
 {
   if (sensor_address_ != device_address) { setSensorAddress(device_address); }
   const std::size_t number_of_bytes = bytes.size();

--- a/lib/io/hardware_i2c.cpp
+++ b/lib/io/hardware_i2c.cpp
@@ -115,12 +115,12 @@ core::Result HardwareI2c::writeByte(const std::uint8_t device_address, const std
 
 void HardwareI2c::setSensorAddress(const std::uint8_t device_address)
 {
-  sensor_address_        = device_address;
   const int return_value = ioctl(file_descriptor_, I2C_SLAVE, device_address);
   if (return_value < 0) {
     logger_.log(core::LogLevel::kFatal, "Failed to set sensor address");
     return;
   }
+  sensor_address_ = device_address;
 }
 
 }  // namespace hyped::io

--- a/lib/io/hardware_i2c.cpp
+++ b/lib/io/hardware_i2c.cpp
@@ -70,10 +70,30 @@ core::Result HardwareI2c::writeByteToRegister(const std::uint8_t device_address,
                                               const std::uint8_t register_address,
                                               const std::uint8_t data)
 {
+  const std::uint8_t register_address_array[2] = {0x00, register_address};
+  return writeByteToDevice(device_address, register_address_array, data);
+}
+
+core::Result HardwareI2c::writeByteToRegister(const std::uint8_t device_address,
+                                              const std::uint16_t register_address,
+                                              const std::uint8_t data)
+{
+  // TODOLater - Is this the best way to do this?
+  const std::uint8_t register_address_hi       = register_address >> 8;
+  const std::uint8_t register_address_lo       = static_cast<std::uint8_t>(register_address);
+  const std::uint8_t register_address_array[2] = {register_address_hi, register_address_lo};
+  return writeByteToDevice(device_address, register_address_array, data);
+}
+
+// TODOLater - Test code
+core::Result HardwareI2c::writeByteToDevice(const std::uint8_t device_address,
+                                            const std::uint8_t register_address_array[2],
+                                            const std::uint8_t data)
+{
   if (sensor_address_ != device_address) { setSensorAddress(device_address); }
-  const std::uint8_t write_buffer[2] = {register_address, data};
-  const ssize_t num_bytes_written    = write(file_descriptor_, write_buffer, 2);
-  if (num_bytes_written != 2) {
+  const std::uint8_t write_buffer[3] = {register_address_array[1], register_address_array[0], data};
+  const ssize_t num_bytes_written    = write(file_descriptor_, write_buffer, 3);
+  if (num_bytes_written != 3) {
     logger_.log(core::LogLevel::kFatal, "Failed to write to i2c device");
     return core::Result::kFailure;
   }

--- a/lib/io/hardware_i2c.hpp
+++ b/lib/io/hardware_i2c.hpp
@@ -23,15 +23,15 @@ class HardwareI2c : public II2c {
   HardwareI2c(core::ILogger &logger, const int file_descriptor);
   ~HardwareI2c();
 
-  virtual std::optional<std::uint8_t> readByte(const std::uint8_t device_address,
-                                               const std::uint8_t register_address);
-  virtual core::Result writeByteToRegister(const std::uint8_t device_address,
-                                           const std::uint8_t register_address,
-                                           const std::uint8_t data);
-  virtual core::Result writeByteToRegister(const std::uint8_t device_address,
-                                           const std::uint16_t register_address,
-                                           const std::uint8_t data);
-  virtual core::Result writeByte(const std::uint8_t device_address, const std::uint8_t data);
+  std::optional<std::uint8_t> readByte(const std::uint8_t device_address,
+                                       const std::uint8_t register_address);
+  core::Result writeByteToRegister(const std::uint8_t device_address,
+                                   const std::uint8_t register_address,
+                                   const std::uint8_t data);
+  core::Result writeByteToRegister(const std::uint8_t device_address,
+                                   const std::uint16_t register_address,
+                                   const std::uint8_t data);
+  core::Result writeByte(const std::uint8_t device_address, const std::uint8_t data);
 
  private:
   void setSensorAddress(const std::uint8_t device_address);

--- a/lib/io/hardware_i2c.hpp
+++ b/lib/io/hardware_i2c.hpp
@@ -28,10 +28,16 @@ class HardwareI2c : public II2c {
   virtual core::Result writeByteToRegister(const std::uint8_t device_address,
                                            const std::uint8_t register_address,
                                            const std::uint8_t data);
+  virtual core::Result writeByteToRegister(const std::uint8_t device_address,
+                                           const std::uint16_t register_address,
+                                           const std::uint8_t data);
   virtual core::Result writeByte(const std::uint8_t device_address, const std::uint8_t data);
 
  private:
   void setSensorAddress(const std::uint8_t device_address);
+  core::Result writeByteToDevice(const std::uint8_t device_address,
+                                 const std::uint8_t register_address_array[2],
+                                 const std::uint8_t data);
 
  private:
   core::ILogger &logger_;

--- a/lib/io/hardware_i2c.hpp
+++ b/lib/io/hardware_i2c.hpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <vector>
 
 #include <core/logger.hpp>
 #include <core/types.hpp>
@@ -35,9 +36,8 @@ class HardwareI2c : public II2c {
 
  private:
   void setSensorAddress(const std::uint8_t device_address);
-  core::Result writeByteToDevice(const std::uint8_t device_address,
-                                 const std::uint8_t register_address_array[2],
-                                 const std::uint8_t data);
+  core::Result writeBytesToDevice(const std::uint8_t device_address,
+                                  const std::vector<std::uint8_t> bytes);
 
  private:
   core::ILogger &logger_;

--- a/lib/io/hardware_i2c.hpp
+++ b/lib/io/hardware_i2c.hpp
@@ -37,7 +37,7 @@ class HardwareI2c : public II2c {
  private:
   void setSensorAddress(const std::uint8_t device_address);
   core::Result writeBytesToDevice(const std::uint8_t device_address,
-                                  const std::vector<std::uint8_t> bytes);
+                                  const std::vector<std::uint8_t> &bytes);
 
  private:
   core::ILogger &logger_;

--- a/lib/io/i2c.hpp
+++ b/lib/io/i2c.hpp
@@ -16,10 +16,18 @@ class II2c {
     = 0;
 
   /**
-   * @brief      General function to write a byte to a register to some device on the I2C bus
+   * @brief      General function to write a byte to an 8-bit register to some device on the I2C bus
    */
   virtual core::Result writeByteToRegister(const std::uint8_t device_address,
                                            const std::uint8_t register_address,
+                                           const std::uint8_t data)
+    = 0;
+
+  /**
+   * @brief      General function to write a byte to a 16-bit register to some device on the I2C bus
+   */
+  virtual core::Result writeByteToRegister(const std::uint8_t device_address,
+                                           const std::uint16_t register_address,
                                            const std::uint8_t data)
     = 0;
 

--- a/lib/io/i2c.hpp
+++ b/lib/io/i2c.hpp
@@ -9,14 +9,15 @@ namespace hyped::io {
 class II2c {
  public:
   /**
-   * @brief      Reads a byte from some device on the I2C bus.
+   * @brief Reads a byte from some device on the I2C bus.
    */
   virtual std::optional<std::uint8_t> readByte(const std::uint8_t device_address,
                                                const std::uint8_t register_address)
     = 0;
 
   /**
-   * @brief      General function to write a byte to an 8-bit register to some device on the I2C bus
+   * @brief General function to write a byte to a register of some device on the I2C bus.
+   * Register addressed by 8-bit value.
    */
   virtual core::Result writeByteToRegister(const std::uint8_t device_address,
                                            const std::uint8_t register_address,
@@ -24,7 +25,8 @@ class II2c {
     = 0;
 
   /**
-   * @brief      General function to write a byte to a 16-bit register to some device on the I2C bus
+   * @brief General function to write a byte to a register of some device on the I2C bus.
+   * Register addressed by 16-bit value.
    */
   virtual core::Result writeByteToRegister(const std::uint8_t device_address,
                                            const std::uint16_t register_address,
@@ -32,7 +34,7 @@ class II2c {
     = 0;
 
   /**
-   * @brief      Writes a byte to single register devices such as the mux
+   * @brief Writes a byte to single register devices such as the mux
    */
   virtual core::Result writeByte(const std::uint8_t device_address, std::uint8_t data) = 0;
 };

--- a/lib/utils/dummy_i2c.cpp
+++ b/lib/utils/dummy_i2c.cpp
@@ -19,6 +19,13 @@ core::Result DummyI2c::writeByteToRegister(const std::uint8_t device_address,
   return core::Result::kFailure;
 }
 
+core::Result DummyI2c::writeByteToRegister(const std::uint8_t device_address,
+                                           const std::uint16_t register_address,
+                                           const std::uint8_t data)
+{
+  return core::Result::kFailure;
+}
+
 core::Result DummyI2c::writeByte(const std::uint8_t device_address, const std::uint8_t data)
 {
   return core::Result::kFailure;

--- a/lib/utils/dummy_i2c.hpp
+++ b/lib/utils/dummy_i2c.hpp
@@ -20,6 +20,9 @@ class DummyI2c : public io::II2c {
   virtual core::Result writeByteToRegister(const std::uint8_t device_address,
                                            const std::uint8_t register_address,
                                            const std::uint8_t data);
+  virtual core::Result writeByteToRegister(const std::uint8_t device_address,
+                                           const std::uint16_t register_address,
+                                           const std::uint8_t data);
   virtual core::Result writeByte(const std::uint8_t device_address, const std::uint8_t data);
 };
 


### PR DESCRIPTION
Update `II2C` and `HardwareI2C` to support writing data to 16-bit registers on I2C devices
(Required to implement Time of Flight sensor)

- [x] Add overloaded `II2C::writeByteToRegister()` to support `uint16_t` register argument
- [x] Add overloaded `HardwareI2C::writeByteToRegister()` to support `uint16_t` register argument
- [x] Implement private `writeByteToDevice()` function for writing to register addressed by either 8 or 16 bits
- [x] Update surrounding I2C code (`dummy_i2c.hpp\.cpp`, `i2c_commands.hpp\.cpp`)
- [ ] Test code for support with 8-bit register requests (ie, all currently implemented I2C sensors)
- [ ] Test code for support with 16-bit register requests (ie, Time of Flight sensors)