### PR TITLE
TEL - Error Dialog Fix

### DIFF
--- a/telemetry/packages/ui/.env.docker
+++ b/telemetry/packages/ui/.env.docker
@@ -4,6 +4,6 @@ VITE_MQTT_QOS=0   # one of 0, 1, 2
 HOST='0.0.0.0'
 
 # Optional
-VITE_DISCONNECTED_MESSAGE_DISABLED=true   # default: false
+VITE_DISABLE_POD_DISCONNECTED_ERROR=true   # default: false
 VITE_HTTP_DEBUG=false   # default: true
 VITE_EXTENDED_DEBUGGING_TOOLS=false   # default: false   

--- a/telemetry/packages/ui/.env.example
+++ b/telemetry/packages/ui/.env.example
@@ -4,6 +4,6 @@ VITE_MQTT_QOS=0   # one of 0, 1, 2
 HOST=   # for docker
 
 # Optional
-VITE_DISCONNECTED_MESSAGE_DISABLED=false   # default: false
+VITE_DISABLE_POD_DISCONNECTED_ERROR=false   # default: false
 VITE_HTTP_DEBUG=true   # default: true
 VITE_EXTENDED_DEBUGGING_TOOLS=false   # default: false   

--- a/telemetry/packages/ui/app/components/sidebar/index.tsx
+++ b/telemetry/packages/ui/app/components/sidebar/index.tsx
@@ -43,17 +43,6 @@ export const Sidebar = ({
     <main className="col-span-1 h-[100vh] border-l-[0px] border-l-openmct-light-gray px-4 py-8 flex flex-col justify-between bg-hyped-background select-none text-gray-100">
       <div className="flex flex-col gap-12 h-full">
         <PodSelector />
-        <button
-          onClick={() => {
-            raiseError(
-              ERROR_IDS.TEST,
-              'Test error',
-              'This is a test error message',
-            );
-          }}
-        >
-          trigger error
-        </button>
         {/* Status, Latency, State, Title */}
         <div className="flex flex-col gap-2">
           <p className="font-bold text-xl">Connection to pod</p>

--- a/telemetry/packages/ui/app/components/sidebar/index.tsx
+++ b/telemetry/packages/ui/app/components/sidebar/index.tsx
@@ -10,7 +10,6 @@ import { PodControls } from './pod-controls';
 import { PodConnectionStatus } from './pod-connection-status';
 import { Logo } from '@/components/shared/logo';
 import { PodSelector } from './pod-selector';
-import { ERROR_IDS, useErrors } from '@/context/errors';
 
 /**
  * The custom sidebar for the GUI which allows us to select a pod, control it, view its connection status, and change the view.
@@ -27,8 +26,6 @@ export const Sidebar = ({
     currentPod,
     pod: { podState },
   } = useCurrentPod();
-
-  const { raiseError } = useErrors();
 
   // Display notification when the pod state changes
   useEffect(

--- a/telemetry/packages/ui/app/config.ts
+++ b/telemetry/packages/ui/app/config.ts
@@ -18,7 +18,7 @@ const envSchema = z.object({
       message: 'QoS must be 0, 1, or 2',
     },
   ),
-  VITE_DISCONNECTED_MESSAGE_DISABLED: booleanFromString.optional(),
+  VITE_DISABLE_POD_DISCONNECTED_ERROR: booleanFromString.optional(),
   VITE_EXTENDED_DEBUGGING_TOOLS: booleanFromString.optional(),
 });
 
@@ -26,8 +26,8 @@ const result = envSchema.safeParse({
   VITE_SERVER_ENDPOINT: import.meta.env.VITE_SERVER_ENDPOINT,
   VITE_MQTT_BROKER: import.meta.env.VITE_MQTT_BROKER,
   VITE_MQTT_QOS: import.meta.env.VITE_MQTT_QOS,
-  VITE_DISCONNECTED_MESSAGE_DISABLED: import.meta.env
-    .VITE_DISCONNECTED_MESSAGE_DISABLED,
+  VITE_DISABLE_POD_DISCONNECTED_ERROR: import.meta.env
+    .VITE_DISABLE_POD_DISCONNECTED_ERROR,
   VITE_EXTENDED_DEBUGGING_TOOLS: import.meta.env.VITE_EXTENDED_DEBUGGING_TOOLS,
 });
 

--- a/telemetry/packages/ui/app/context/errors.tsx
+++ b/telemetry/packages/ui/app/context/errors.tsx
@@ -1,3 +1,4 @@
+import { config } from '@/config';
 import { log } from '@/lib/logger';
 import { PodId } from '@hyped/telemetry-constants';
 import { createContext, useContext, useState } from 'react';
@@ -47,6 +48,14 @@ export const ErrorProvider = ({ children }: ErrorProviderProps) => {
     message: string,
     podId?: PodId,
   ) => {
+    // If the error is a pod disconnect error and the config is set to disable it, don't raise the error
+    if (
+      config.DISABLE_POD_DISCONNECTED_ERROR &&
+      id === ERROR_IDS.POD_DISCONNECT
+    ) {
+      return;
+    }
+
     const error: ErrorMessage = {
       id,
       title,

--- a/telemetry/packages/ui/app/context/pods.tsx
+++ b/telemetry/packages/ui/app/context/pods.tsx
@@ -85,7 +85,7 @@ function createPodsStateFromIds(podIds: typeof POD_IDS): PodsStateType {
       id: podId,
       name: pods[podId].name,
       operationMode: pods[podId].operationMode,
-      connectionStatus: POD_CONNECTION_STATUS.DISCONNECTED,
+      connectionStatus: POD_CONNECTION_STATUS.CONNECTED,
       podState: ALL_POD_STATES.UNKNOWN,
     };
   }
@@ -114,19 +114,24 @@ export const PodsProvider = ({ children }: { children: React.ReactNode }) => {
      * When the MQTT connection status changes, check if we need to set the pod connection statuses to disconnected.
      */
     function checkMqttConnectionStatus() {
-      // If we don't have an MQTT connection, set all pod connection statuses to disconnected
+      // If the MQTT connection status has changed to disconnected, set all pod connection statuses to disconnected
       if (mqttConnectionStatus !== MQTT_CONNECTION_STATUS.CONNECTED) {
         setPodsState((prevState) => {
           const newPodsState = { ...prevState };
           for (const podId of POD_IDS) {
-            newPodsState[podId].connectionStatus =
-              POD_CONNECTION_STATUS.DISCONNECTED;
-            raiseError(
-              ERROR_IDS.POD_DISCONNECT,
-              `Pod ${podId} disconnected!`,
-              `Lost connection to ${podId} because the connection to the MQTT broker has been lost.`,
-              podId,
-            );
+            if (
+              newPodsState[podId].connectionStatus !==
+              POD_CONNECTION_STATUS.DISCONNECTED
+            ) {
+              newPodsState[podId].connectionStatus =
+                POD_CONNECTION_STATUS.DISCONNECTED;
+              raiseError(
+                ERROR_IDS.POD_DISCONNECT,
+                `Pod ${podId} disconnected!`,
+                `Lost connection to ${podId} because the connection to the MQTT broker has been lost.`,
+                podId,
+              );
+            }
           }
           return newPodsState;
         });


### PR DESCRIPTION
- Fixes bug where pod disconnect errors are repeatedly raised if the GUI is not connected to an MQTT broker.
- Adds `VITE_DISABLE_POD_DISCONNECTED_ERROR` environment variable to disable these errors altogether (useful for dev and testing)