### PR TITLE
TEL - Raise critical error when pod enters a failure state

### DIFF
--- a/telemetry/packages/ui/app/context/errors.tsx
+++ b/telemetry/packages/ui/app/context/errors.tsx
@@ -4,6 +4,7 @@ import { createContext, useContext, useState } from 'react';
 
 export const ERROR_IDS = {
   POD_DISCONNECT: 'POD_DISCONNECT',
+  POD_FAILURE_STATE: 'POD_FAILURE_STATE',
   TEST: 'TEST',
 };
 

--- a/telemetry/packages/ui/app/context/pods.tsx
+++ b/telemetry/packages/ui/app/context/pods.tsx
@@ -16,6 +16,7 @@ import {
 } from '@hyped/telemetry-constants';
 import { http } from 'openmct/core/http';
 import { ERROR_IDS, useErrors } from './errors';
+import { FAILURE_STATES } from '@hyped/telemetry-constants';
 
 /**
  * The maximum latency before a pod is considered disconnected, in milliseconds
@@ -200,11 +201,7 @@ export const PodsProvider = ({ children }: { children: React.ReactNode }) => {
      */
     function subscribeToMqttAndLatency() {
       if (!client) return;
-      const processMessage = (
-        podId: string,
-        topic: string,
-        message: Buffer,
-      ) => {
+      const processMessage = (podId: PodId, topic: string, message: Buffer) => {
         if (topic === getTopic('state', podId)) {
           const newPodState = message.toString();
           const allowedStates = Object.values(ALL_POD_STATES);
@@ -216,6 +213,15 @@ export const PodsProvider = ({ children }: { children: React.ReactNode }) => {
                 podState: newPodState as PodStateType,
               },
             }));
+          }
+          // raise an error if we are in a failure state
+          if (Object.keys(FAILURE_STATES).includes(newPodState)) {
+            raiseError(
+              ERROR_IDS.POD_FAILURE_STATE,
+              `Pod ${podId} in failure state!`,
+              `Pod ${podId} is in a failure state.`,
+              podId,
+            );
           }
         } else if (topic === getTopic('latency/response', podId)) {
           // calculate the latency


### PR DESCRIPTION
The GUI will now display an error using the error dialog when it hears a state transition to the `FAILURE_BRAKING` state.

<details><summary>Screenshot</summary>
<p>

![image](https://github.com/Hyp-ed/hyped-2024/assets/43144010/a8c921da-d4a0-454c-9dba-c35786088021)

</p>
</details> 